### PR TITLE
Honor batch limit in coreset evaluations

### DIFF
--- a/coreset_evaluation.py
+++ b/coreset_evaluation.py
@@ -278,7 +278,8 @@ def main():
                            collate_fn=collate_fn, pin_memory=device.type == "cuda")
     sample_weights_tensor = torch.tensor(sample_weights, dtype=torch.float)
     coreset_total_weighted_loss, coreset_avg_loss, coreset_total_samples = evaluate_model(
-        model, dl_sensitivity_coreset, device, weights=sample_weights_tensor, max_num_batches=None)
+        model, dl_sensitivity_coreset, device, weights=sample_weights_tensor,
+        max_num_batches=args.max_num_batches)
     print(f"Coreset total weighted loss: {coreset_total_weighted_loss:.4f}")
     print(f"Coreset average loss: {coreset_avg_loss:.4f}")
     print(f"Full subset loss: {total_loss:.4f}")
@@ -315,7 +316,7 @@ def main():
     
     # Evaluate on coreset with weighted loss
     coreset_total_weighted_loss, coreset_avg_loss, coreset_total_samples = evaluate_model(
-        model, dl_uniform, device, weights=weight, max_num_batches=None)
+        model, dl_uniform, device, weights=weight, max_num_batches=args.max_num_batches)
     print(f"Coreset total weighted loss: {coreset_total_weighted_loss:.4f}")
     print(f"Coreset average loss: {coreset_avg_loss:.4f}")
     print(f"Full subset loss: {total_loss:.4f}")


### PR DESCRIPTION
## Summary
- limit sensitivity and uniform coreset evaluations using `args.max_num_batches`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685bd7229eb08322955d608641e05150