### PR TITLE
Add weighted coreset training support

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -5,12 +5,20 @@ from tqdm import tqdm
 
 
 def evaluate_accuracy(model: nn.Module, dataloader: DataLoader, device: torch.device) -> float:
-    """Return accuracy of *model* on *dataloader*."""
+    """Return accuracy of *model* on ``dataloader``.
+
+    The dataloader may optionally yield sample weights alongside each batch.
+    These weights are ignored for accuracy computation.
+    """
     model.eval()
     correct = 0
     total = 0
     with torch.no_grad():
-        for x, y in tqdm(dataloader, desc="Evaluating accuracy", leave=False):
+        for batch in tqdm(dataloader, desc="Evaluating accuracy", leave=False):
+            if len(batch) == 3:
+                x, y, _ = batch
+            else:
+                x, y = batch
             x = x.to(device)
             y = y.to(device)
             logits = model(x)


### PR DESCRIPTION
## Summary
- implement `WeightedSubset` dataset and extend collate to handle weights
- add `WeightedRandomSampler` option in `make_subset_loader`
- train using per-sample weights in `run_training`
- allow `evaluate_accuracy` and other helpers to ignore optional weights
- wire uniform and sensitivity coresets to pass weights
- document weighted dataset and loader behaviour

## Testing
- `python -m py_compile train_finetune.py utils.py coreset.py`


------
https://chatgpt.com/codex/tasks/task_e_685d0ba96a488322ba3787b9ad18a582